### PR TITLE
 added support for implicit deducing of LUT, and trimming decrypted files

### DIFF
--- a/smm2crypt/keys.h
+++ b/smm2crypt/keys.h
@@ -1,0 +1,18 @@
+#ifndef KEYS_H
+#define KEYS_H
+
+#include "types.h"
+
+// these keys must be hard coded to be used
+
+u32 course_key_table[64] = {0};
+u32 replay_key_table[64] = {0};
+u32 later_key_table[64] = {0};
+u32 save_key_table[64] = {0};
+u32 quest_key_table[64] = {0};
+u32 network_key_table[64] = {0};
+u32 info_key_table[64] ={0};
+u32 thumb_key_table[64] = {0};
+u32 unknown_key_table[64] = {0};
+
+#endif

--- a/smm2crypt/main.c
+++ b/smm2crypt/main.c
@@ -16,7 +16,7 @@ typedef struct {
 	u32 product_version;
 	u32 develop_version;
 	u32 crc32;
-	u32 pad;
+	u32 magic;
 } save_header;
 
 typedef struct {
@@ -31,18 +31,19 @@ struct mm_file_type
 	char* fileName;
 	size_t fileSize;
 	u32 develop_version;
+	u32 magic;
 	u32* key_table;
 };
 
 struct mm_file_type file_types[] = {
-	{ "save", "save.dat", 0xC000, 0x0B, save_key_table },
-	{ "quest", "quest.dat", 0xC000, 0x01, quest_key_table },
-	{ "later", "later.dat", 0xC000, 0x0A, later_key_table },
-	{ "replay", ".dat", 0x68000, 0x0, replay_key_table },
-	{ "network", "network.dat", 0x48000, 0x08, network_key_table },
-	{ "thumb", ".btl", 0x1C000, 0x0, thumb_key_table },
-	{ "thumb", ".jpg", 0x1C000, 0x0, thumb_key_table },
-	{ "course", ".bcd", 0x5C000, 0x10, course_key_table }
+	{ "save", "save.dat", 0xC000, 0x0B, 0x00, save_key_table },
+	{ "quest", "quest.dat", 0xC000, 0x01, 0x00, quest_key_table },
+	{ "later", "later.dat", 0xC000, 0x0A, 0x00, later_key_table },
+	{ "replay", ".dat", 0x68000, 0x00, 0x00, replay_key_table },
+	{ "network", "network.dat", 0x48000, 0x08, 0x00, network_key_table },
+	{ "thumb", ".btl", 0x1C000, 0x00, 0x00, thumb_key_table },
+	{ "thumb", ".jpg", 0x1C000, 0x00, 0x00, thumb_key_table },
+	{ "course", ".bcd", 0x5C000, 0x10, 0x4C444353, course_key_table }
 };
 
 char ends_with(const char* a, const char* b)
@@ -114,7 +115,7 @@ u32* get_lookup_table(const char* fileName, size_t size, save_header* header, bo
 				header->product_version = 1;
 				header->develop_version = file_types[i].develop_version;
 				header->crc32 = 0;
-				header->pad = 0;
+				header->magic = file_types[i].magic;
 			}
 
 			if (file_types[i].develop_version && offset)

--- a/smm2crypt/main.c
+++ b/smm2crypt/main.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
-#include "dirent.h"
+#include <dirent.h>
 #include <openssl/aes.h> 
 #include <openssl/cmac.h>
 

--- a/smm2crypt/utils.h
+++ b/smm2crypt/utils.h
@@ -48,6 +48,7 @@ int deldir(const char* dir);
 
 // rewinds to 0 when done
 size_t get_fsize(FILE* f);
+bool file_put_contents(const char* file_name, const void* buffer, size_t size);
 // returns number of consecutive zero bytes from offset 0, up to max_len
 int get_zeroes(u8* data, int max_len);
 


### PR DESCRIPTION
User can supply a LUT file, or let the program try to deduce the correct LUT.

Decrypting a file strips the save header and security footer from the file, conversely encrypting a file adds them.